### PR TITLE
Fix-getQuizById-replace_params-by-query

### DIFF
--- a/.github/workflows/back-end-cd.yml
+++ b/.github/workflows/back-end-cd.yml
@@ -1,6 +1,9 @@
 name: CD
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/controllers/quizzes.js
+++ b/controllers/quizzes.js
@@ -47,7 +47,7 @@ exports.getQuizzes = async (req, res, next) => {
 // qui veut répondre dans un second temps au quiz
 exports.getQuizById = async (req, res, next) => {
   try {
-    const quiz = await Quiz.findOne({ _id: req.params.id });
+    const quiz = await Quiz.findOne({ _id: req.query.id });
     res.status(200).send({
       quiz,
     });

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -25,27 +25,23 @@ exports.signup = (req, res) => bcrypt.hash(req.body.password, 10)
 exports.login = (req, res) => User.findOne({ email: req.body.email })
   .then((user) => {
     if (!user) {
-      res.status(401).json({ error: 'Utilisateur non trouvé !' });
+      return res.status(401).json({ error: 'Utilisateur non trouvé !' });
     }
-    bcrypt.compare(req.body.password, user.password)
+    return bcrypt.compare(req.body.password, user.password)
       .then((valid) => {
         if (!valid) {
-          res.status(401).json({ error: 'Mot de passe incorrect !' });
-        } else {
-          res.status(200).json({
-            userId: user._id,
-            token: jwt.sign(
-              {
-                userId: user._id,
-              },
-              'RANDOM_TOKEN_SECRET',
-              { expiresIn: '24h' },
-            ),
-          });
+          return res.status(401).json({ error: 'Mot de passe incorrect !' });
         }
-      }).catch((error) => {
-        res.status(500).json({ error });
-      });
+        return res.status(200).json({
+          userId: user._id,
+          token: jwt.sign(
+            { userId: user._id },
+            'RANDOM_TOKEN_SECRET',
+            { expiresIn: '24h' },
+          ),
+        });
+      })
+      .catch((error) => res.status(500).json({ error }));
   })
   .catch((error) => res.status(500).json({ error }));
 

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -194,7 +194,9 @@ describe('User', async () => {
         },
       };
 
-      const findOneStub = await sinon.stub(UserTest, 'findOne').callsFake(() => Promise.resolve(false));
+      const user = undefined;
+
+      const findOneStub = await sinon.stub(UserTest, 'findOne').callsFake(() => Promise.resolve(user));
       await userController.login(req, res);
       expect(findOneStub.calledOnce).to.be.true;
       expect(res.resultStatus).to.eq(401);


### PR DESCRIPTION
fix une erreur passée sous les radars: lorsqu'on voulait se logger avec un mauvais utilisateur le login faisait crasher le serveur...

modifie le déploiement pour qu'il ne se fasse que lors des merge sur main (et non plus a chaque ouverture de PR...)

corrige un petit truc sur getQuizById mais peut etre deja réglé sur une autre PR?