### PR TITLE
fix-most-recent-quiz-appears-first

### DIFF
--- a/controllers/quizzes.js
+++ b/controllers/quizzes.js
@@ -31,7 +31,7 @@ exports.getQuizzes = async (req, res, next) => {
       res.status(400).send('invalid request in quantity');
     } else {
       const quizzes = await Quiz.find()
-        .sort({ _id: 1 })
+        .sort({ _id: -1 })
         .limit(limit)
         .skip(skipIndex)
         .exec();


### PR DESCRIPTION
In the Explore Page, now it is the last quiz created that appears on top of the page